### PR TITLE
Use abstract-most interface

### DIFF
--- a/src/main/java/joptsimple/internal/Strings.java
+++ b/src/main/java/joptsimple/internal/Strings.java
@@ -26,7 +26,6 @@
 package joptsimple.internal;
 
 import java.util.Iterator;
-import java.util.List;
 
 import static java.lang.System.*;
 import static java.util.Arrays.*;
@@ -101,7 +100,7 @@ public final class Strings {
      * @param separator the separator
      * @return the joined string
      */
-    public static String join( List<String> pieces, String separator ) {
+    public static String join( Iterable<String> pieces, String separator ) {
         StringBuilder buffer = new StringBuilder();
 
         for ( Iterator<String> iter = pieces.iterator(); iter.hasNext(); ) {


### PR DESCRIPTION
Since Strings does not use any List-specific method, forcing the invoker to down-cast the argument as a List (or even build a List from an imcompatible type as Set) I propose to accept `Iterable<T>` as argument.

Please note I have done modifications from GitHub UI