### PR TITLE
Fix the build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,6 +260,11 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>2.8</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.9.1</version>
                 <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -205,13 +205,13 @@
                         <id>paste-examples</id>
                         <phase>post-site</phase>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <property name="java.io.tmpdir" value="${java.io.tmpdir}" />
                                 <property name="example.src.dir" value="src/test/java" />
                                 <property name="example.class.path" refid="maven.test.classpath" />
                                 <property name="website.staging.dir" value="${project.build.directory}/site" />
                                 <ant antfile="paste-examples.xml" target="-paste-examples" />
-                            </tasks>
+                            </target>
                         </configuration>
                         <goals>
                             <goal>run</goal>

--- a/src/main/java/joptsimple/OptionParser.java
+++ b/src/main/java/joptsimple/OptionParser.java
@@ -156,7 +156,7 @@ import static joptsimple.ParserRules.*;
  * </ol>
  *
  * <p>Each of the options in a list of options given to {@link #acceptsAll(List) acceptsAll} is treated as a
- * synonym of the others.  For example:
+ * synonym of the others.  For example:</p>
  *   <pre>
  *     <code>
  *     OptionParser parser = new OptionParser();
@@ -164,7 +164,7 @@ import static joptsimple.ParserRules.*;
  *     OptionSet options = parser.parse( "-w" );
  *     </code>
  *   </pre>
- * In this case, <code>options.{@link OptionSet#has(String) has}</code> would answer {@code true} when given arguments
+ * <p>In this case, <code>options.{@link OptionSet#has(String) has}</code> would answer {@code true} when given arguments
  * {@code "w"}, {@code "interactive"}, and {@code "confirmation"}. The {@link OptionSet} would give the same
  * responses to these arguments for its other methods as well.</p>
  *

--- a/src/site/apt/developer.apt
+++ b/src/site/apt/developer.apt
@@ -6,7 +6,7 @@ Help for developing JOpt Simple
 
   This page has notes and hints for contributing to JOpt Simple, mostly around getting started and style questions.
 
-* {{Code Style}}
+* Code Style
 
   Style is important.  Why?  Chiefly to aid merges.  Reformatting code makes merging more difficult.  When needing to reformat unchanged code, please do so on a separate commit with a clear commit message indicating a non-code change.
 
@@ -14,7 +14,7 @@ Help for developing JOpt Simple
 
   The ultimate arbiter of good style is Paul Holser.
 
-** {{Braces}}
+** Braces
 
   * Yes:
 

--- a/src/test/java/joptsimple/util/InetAddressConverterTest.java
+++ b/src/test/java/joptsimple/util/InetAddressConverterTest.java
@@ -47,9 +47,9 @@ public class InetAddressConverterTest {
 
     @Test
     public void localhost() throws Exception {
-       assumeTrue( InetAddress.getByName( "127.0.0.1" ).isReachable( 5000 ) );
+        assumeTrue( InetAddress.getByName( "127.0.0.1" ).isReachable( 5000 ) );
 
-       assertEquals( "127.0.0.1", converter.convert( "localhost" ).getHostAddress() );
+        assertEquals( "127.0.0.1", converter.convert( "localhost" ).getHostAddress() );
     }
 
     @Test( expected = ValueConversionException.class )

--- a/src/test/java/joptsimple/util/InetAddressConverterTest.java
+++ b/src/test/java/joptsimple/util/InetAddressConverterTest.java
@@ -26,6 +26,7 @@
 package joptsimple.util;
 
 import java.net.InetAddress;
+import java.util.Random;
 
 import joptsimple.ValueConversionException;
 import org.junit.Before;
@@ -54,6 +55,6 @@ public class InetAddressConverterTest {
 
     @Test( expected = ValueConversionException.class )
     public void unknownHost() {
-        converter.convert( "yer.mom" );
+        converter.convert( String.valueOf( new Random().nextDouble() ) );
     }
 }


### PR DESCRIPTION
I noticed the developer.html and wanted to ensure that the change I made to the pom in #81 didn't inadvertently break something. Whew, buddy, was that a rabbit-hole.

* The failing test was malformated according to the eclipse formatting plugin; fixed
* The test was failing because [.mom is now a gTLD](https://www.icann.org/resources/agreement/mom-2015-04-16-en); fixed
* The build fails on Java 8 because of the more strict javadoc doclet; fixed
* The apt generator was whining about a malformed anchor tag; fixed
* The `ant-run` plugin was warning about a deprecated syntax (and that task also fails for me, but it didn't fail the build, so I guess I win); fixed
* Maven is rattling sabers about version-less plugins, so best to nip that in the bud