### PR TITLE
For #85, correct built-in help description column width

### DIFF
--- a/src/main/java/joptsimple/BuiltinHelpFormatter.java
+++ b/src/main/java/joptsimple/BuiltinHelpFormatter.java
@@ -116,7 +116,7 @@ public class BuiltinHelpFormatter implements HelpFormatter {
      * @param right text to put in the right column
      */
     protected void addOptionRow( String left, String right ) {
-        optionRows.add(left, right);
+        optionRows.add( left, right );
     }
 
     /**
@@ -224,7 +224,7 @@ public class BuiltinHelpFormatter implements HelpFormatter {
      */
     protected void addNonOptionsDescription( Collection<? extends OptionDescriptor> options ) {
         OptionDescriptor nonOptions = findAndRemoveNonOptionsSpec( options );
-        if ( shouldShowNonOptionArgumentDisplay(nonOptions) ) {
+        if ( shouldShowNonOptionArgumentDisplay( nonOptions ) ) {
             addNonOptionRow( message( "non.option.arguments.header" ) );
             addNonOptionRow( createNonOptionArgumentsDisplay( nonOptions ) );
         }

--- a/src/main/java/joptsimple/internal/Columns.java
+++ b/src/main/java/joptsimple/internal/Columns.java
@@ -28,7 +28,6 @@ package joptsimple.internal;
 import java.text.BreakIterator;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 
 import static java.text.BreakIterator.*;
 
@@ -75,7 +74,7 @@ class Columns {
     private List<String> piecesOfEmbeddedLine( String line, int width ) {
         List<String> pieces = new ArrayList<String>();
 
-        BreakIterator words = BreakIterator.getLineInstance( Locale.US );
+        BreakIterator words = BreakIterator.getLineInstance();
         words.setText( line );
 
         StringBuilder nextPiece = new StringBuilder();

--- a/src/main/java/joptsimple/internal/Rows.java
+++ b/src/main/java/joptsimple/internal/Rows.java
@@ -92,7 +92,7 @@ public class Rows {
     }
 
     private int descriptionWidth() {
-        return min( ( overallWidth - columnSeparatorWidth ) / 2, widthOfWidestDescription );
+        return min( overallWidth - optionWidth() - columnSeparatorWidth, widthOfWidestDescription );
     }
 
     private StringBuilder pad( StringBuilder buffer, String s, int length ) {

--- a/src/site/apt/changes.apt
+++ b/src/site/apt/changes.apt
@@ -2,6 +2,12 @@
                                        Change Log
                                        ----------
 
+Changes in version 4.10
+
+    * Resolved {{{https://github.com/pholser/jopt-simple/issues/85} gh-85}}
+      by correcting the description column width consumption of the built-in
+      help formatter.
+
 Changes in version 4.9
 
     * Resolved {{{https://github.com/pholser/jopt-simple/issues/79} gh-79}}

--- a/src/test/java/joptsimple/ConfigurableOptionParserHelpTest.java
+++ b/src/test/java/joptsimple/ConfigurableOptionParserHelpTest.java
@@ -67,10 +67,10 @@ public class ConfigurableOptionParserHelpTest extends AbstractOptionParserFixtur
         parser.printHelpOn( sink );
 
         assertHelpLines(
-                "Option    Description",
-                "------    -----------",
-                "--apple              ",
-                EMPTY );
+            "Option    Description",
+            "------    -----------",
+            "--apple              ",
+            EMPTY );
     }
 
     @Test
@@ -143,7 +143,7 @@ public class ConfigurableOptionParserHelpTest extends AbstractOptionParserFixtur
     @Test
     public void oneOptionRequiredArgWithDescriptionAndType() throws Exception {
         parser.accepts( "a", "some value you need" ).withRequiredArg().describedAs( "numerical" )
-                .ofType( Integer.class );
+            .ofType( Integer.class );
 
         parser.printHelpOn( sink );
 
@@ -196,7 +196,7 @@ public class ConfigurableOptionParserHelpTest extends AbstractOptionParserFixtur
     @Test
     public void oneOptionOptionalArgWithDescriptionAndType() throws Exception {
         parser.accepts( "threshold", "some value you need" ).withOptionalArg().describedAs( "positive decimal" )
-                .ofType( Double.class );
+            .ofType( Double.class );
 
         parser.printHelpOn( sink );
 
@@ -249,7 +249,7 @@ public class ConfigurableOptionParserHelpTest extends AbstractOptionParserFixtur
     @Test
     public void optionSynonymsWithOptionalArgument() throws Exception {
         parser.acceptsAll( asList( "d", "since" ), "date filter" ).withOptionalArg().describedAs( "yyyyMMdd" )
-                .ofType( Date.class );
+            .ofType( Date.class );
 
         parser.printHelpOn( sink );
 
@@ -337,38 +337,32 @@ public class ConfigurableOptionParserHelpTest extends AbstractOptionParserFixtur
         parser.printHelpOn( sink );
 
         assertHelpLines(
-            "Option                         Description                                               ",
-            "------                         -----------                                               ",
-            "-?, -h                         Shows this help message.                                  ",
-            "-B, --bootstrap-debug          Specify a text to be logged at the beginning (e.g. used   ",
-            "                                 by Gradle's bootstrap class).                           ",
-            "-D, --systemprop               Set system property of the JVM (e.g. -Dmyprop=myvalue).   ",
-            "-I, --no-imports               Disable usage of default imports for build script files.  ",
-            "-P, --projectprop              Set project property for the build script (e.g. -         ",
-            "                                 Pmyprop=myvalue).                                       ",
-            "-S                             Don't trigger a System.exit(0) for normal termination.    ",
-            "                                 Used for Gradle's internal testing.                     ",
-            "-b, --buildfile                Specifies the build file name (also for subprojects).     ",
-            "                                 Defaults to build.gradle.                               ",
-            "-d, --debug                    Log in debug mode (includes normal stacktrace).           ",
-            "-e, --embedded                 Specify an embedded build script.                         ",
-            "-f, --full-stacktrace          Print out the full (very verbose) stacktrace for any      ",
-            "                                 exceptions.                                             ",
-            "-g, --gradle-user-home         Specifies the gradle user home dir.                       ",
-            "-i, --ivy-quiet                Set Ivy log level to quiet.                               ",
-            "-j, --ivy-debug                Set Ivy log level to debug (very verbose).                ",
-            "-l, --plugin-properties-file   Specifies the plugin.properties file.                     ",
-            "-n, --non-recursive            Do not execute primary tasks of child projects.           ",
-            "-p, --project-dir              Specifies the start dir for Gradle. Defaults to current   ",
-            "                                 dir.                                                    ",
-            "-q, --quiet                    Log errors only.                                          ",
-            "-r, --rebuild-cache            Rebuild the cache of compiled build scripts.              ",
-            "-s, --stacktrace               Print out the stacktrace also for user exceptions (e.g.   ",
-            "                                 compile error).                                         ",
-            "-t, --tasks                    Show list of all available tasks and their dependencies.  ",
-            "-u, --no-search-upward         Don't search in parent folders for a settings.gradle file.",
-            "-v, --version                  Print version info.                                       ",
-            "-x, --cache-off                No caching of compiled build scripts.                     ",
+            "Option                         Description                                                                          ",
+            "------                         -----------                                                                          ",
+            "-?, -h                         Shows this help message.                                                             ",
+            "-B, --bootstrap-debug          Specify a text to be logged at the beginning (e.g. used by Gradle's bootstrap class).",
+            "-D, --systemprop               Set system property of the JVM (e.g. -Dmyprop=myvalue).                              ",
+            "-I, --no-imports               Disable usage of default imports for build script files.                             ",
+            "-P, --projectprop              Set project property for the build script (e.g. -Pmyprop=myvalue).                   ",
+            "-S                             Don't trigger a System.exit(0) for normal termination. Used for Gradle's internal    ",
+            "                                 testing.                                                                           ",
+            "-b, --buildfile                Specifies the build file name (also for subprojects). Defaults to build.gradle.      ",
+            "-d, --debug                    Log in debug mode (includes normal stacktrace).                                      ",
+            "-e, --embedded                 Specify an embedded build script.                                                    ",
+            "-f, --full-stacktrace          Print out the full (very verbose) stacktrace for any exceptions.                     ",
+            "-g, --gradle-user-home         Specifies the gradle user home dir.                                                  ",
+            "-i, --ivy-quiet                Set Ivy log level to quiet.                                                          ",
+            "-j, --ivy-debug                Set Ivy log level to debug (very verbose).                                           ",
+            "-l, --plugin-properties-file   Specifies the plugin.properties file.                                                ",
+            "-n, --non-recursive            Do not execute primary tasks of child projects.                                      ",
+            "-p, --project-dir              Specifies the start dir for Gradle. Defaults to current dir.                         ",
+            "-q, --quiet                    Log errors only.                                                                     ",
+            "-r, --rebuild-cache            Rebuild the cache of compiled build scripts.                                         ",
+            "-s, --stacktrace               Print out the stacktrace also for user exceptions (e.g. compile error).              ",
+            "-t, --tasks                    Show list of all available tasks and their dependencies.                             ",
+            "-u, --no-search-upward         Don't search in parent folders for a settings.gradle file.                           ",
+            "-v, --version                  Print version info.                                                                  ",
+            "-x, --cache-off                No caching of compiled build scripts.                                                ",
             EMPTY );
     }
 
@@ -388,7 +382,7 @@ public class ConfigurableOptionParserHelpTest extends AbstractOptionParserFixtur
     @Test
     public void dateConverterShowsDatePatternInCombinationWithDescription() throws Exception {
         parser.accepts( "date", "a date" ).withOptionalArg().describedAs( "your basic date pattern" )
-                .withValuesConvertedBy( datePattern( "MM/dd/yy" ) );
+            .withValuesConvertedBy( datePattern( "MM/dd/yy" ) );
 
         parser.printHelpOn( sink );
 
@@ -402,7 +396,7 @@ public class ConfigurableOptionParserHelpTest extends AbstractOptionParserFixtur
     @Test
     public void leavesEmbeddedNewlinesInDescriptionsAlone() throws Exception {
         List<String> descriptionPieces =
-                asList( "Specify the output type.", "'raw' = raw data.", "'java' = java class" );
+            asList( "Specify the output type.", "'raw' = raw data.", "'java' = java class" );
         parser.accepts( "type", join( descriptionPieces, LINE_SEPARATOR ) );
 
         parser.printHelpOn( sink );
@@ -445,7 +439,7 @@ public class ConfigurableOptionParserHelpTest extends AbstractOptionParserFixtur
     @Test
     public void includesDefaultValueForArgumentWithDescription() throws Exception {
         parser.accepts( "c", "a quantity" ).withOptionalArg().ofType( BigDecimal.class )
-                .describedAs( "quantity" ).defaultsTo( TEN );
+            .describedAs( "quantity" ).defaultsTo( TEN );
 
         parser.printHelpOn( sink );
 
@@ -459,7 +453,7 @@ public class ConfigurableOptionParserHelpTest extends AbstractOptionParserFixtur
     @Test
     public void includesListOfDefaultsForArgumentWithDescription() throws Exception {
         parser.accepts( "d", "dizzle" ).withOptionalArg().ofType( Integer.class )
-                .describedAs( "double dizzle" ).defaultsTo( 2, 3, 5, 7 );
+            .describedAs( "double dizzle" ).defaultsTo( 2, 3, 5, 7 );
 
         parser.printHelpOn( sink );
 

--- a/src/test/java/joptsimple/DefaultSettingsOptionParserHelpTest.java
+++ b/src/test/java/joptsimple/DefaultSettingsOptionParserHelpTest.java
@@ -27,7 +27,6 @@ package joptsimple;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.IOException;
 import java.io.StringWriter;
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -35,14 +34,13 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-import static java.math.BigDecimal.*;
-import static java.util.Arrays.*;
-import static java.util.Collections.*;
-
 import joptsimple.util.InetAddressConverter;
 import org.junit.Before;
 import org.junit.Test;
 
+import static java.math.BigDecimal.*;
+import static java.util.Arrays.*;
+import static java.util.Collections.*;
 import static joptsimple.internal.Strings.*;
 import static joptsimple.util.DateConverter.*;
 import static org.junit.Assert.*;
@@ -375,55 +373,50 @@ public class DefaultSettingsOptionParserHelpTest extends AbstractOptionParserFix
         parser.printHelpOn( sink );
 
         assertHelpLines(
-            "Option                        Description                           ",
-            "------                        -----------                           ",
-            "-?, -h                        Shows this help message               ",
-            "-B, --bootstrap-debug         Specify a text to be logged at the    ",
-            "                                beginning (e.g. used by Gradle's    ",
-            "                                bootstrap class.                    ",
-            "-D, --systemprop              Set system property of the JVM (e.g. -",
-            "                                Dmyprop=myvalue).                   ",
-            "-I, --no-imports              Disable usage of default imports for  ",
-            "                                build script files.                 ",
-            "-P, --projectprop             Set project property for the build    ",
-            "                                script (e.g. -Pmyprop=myvalue).     ",
-            "-S                            Don't trigger a System.exit(0) for    ",
-            "                                normal termination. Used for        ",
-            "                                Gradle's internal testing.          ",
-            "-b, --buildfile               Specifies the build file name (also   ",
-            "                                for subprojects). Defaults to build.",
-            "                                gradle.                             ",
-            "-d, --debug                   Log in debug mode (includes normal    ",
-            "                                stacktrace).                        ",
-            "-e, --embedded                Specify an embedded build script.     ",
-            "-f, --full-stacktrace         Print out the full (very verbose)     ",
-            "                                stacktrace for any exceptions.      ",
-            "-g, --gradle-user-home        Specifies the gradle user home dir.   ",
-            "-i, --ivy-quiet               Set Ivy log level to quiet.           ",
-            "-j, --ivy-debug               Set Ivy log level to debug (very      ",
-            "                                verbose).                           ",
-            "-l, --plugin-properties-file  Specifies the plugin.properties file. ",
-            "-n, --non-recursive           Do not execute primary tasks of child ",
-            "                                projects.                           ",
-            "-p, --project-dir             Specifies the start dir for Gradle.   ",
-            "                                Defaults to current dir.            ",
-            "-q, --quiet                   Log errors only.                      ",
-            "-r, --rebuild-cache           Rebuild the cache of compiled build   ",
-            "                                scripts.                            ",
-            "-s, --stacktrace              Print out the stacktrace also for user",
-            "                                exceptions (e.g. compile error).    ",
-            "-t, --tasks                   Show list of all available tasks and  ",
-            "                                their dependencies.                 ",
-            "-u, --no-search-upward        Don't search in parent folders for a  ",
-            "                                settings.gradle file.               ",
-            "-v, --version                 Print version info.                   ",
-            "-x, --cache-off               No caching of compiled build scripts. ",
+            "Option                        Description                                       ",
+            "------                        -----------                                       ",
+            "-?, -h                        Shows this help message                           ",
+            "-B, --bootstrap-debug         Specify a text to be logged at the beginning (e.  ",
+            "                                g. used by Gradle's bootstrap class.            ",
+            "-D, --systemprop              Set system property of the JVM (e.g. -            ",
+            "                                Dmyprop=myvalue).                               ",
+            "-I, --no-imports              Disable usage of default imports for build script ",
+            "                                files.                                          ",
+            "-P, --projectprop             Set project property for the build script (e.g. - ",
+            "                                Pmyprop=myvalue).                               ",
+            "-S                            Don't trigger a System.exit(0) for normal         ",
+            "                                termination. Used for Gradle's internal testing.",
+            "-b, --buildfile               Specifies the build file name (also for           ",
+            "                                subprojects). Defaults to build.gradle.         ",
+            "-d, --debug                   Log in debug mode (includes normal stacktrace).   ",
+            "-e, --embedded                Specify an embedded build script.                 ",
+            "-f, --full-stacktrace         Print out the full (very verbose) stacktrace for  ",
+            "                                any exceptions.                                 ",
+            "-g, --gradle-user-home        Specifies the gradle user home dir.               ",
+            "-i, --ivy-quiet               Set Ivy log level to quiet.                       ",
+            "-j, --ivy-debug               Set Ivy log level to debug (very verbose).        ",
+            "-l, --plugin-properties-file  Specifies the plugin.properties file.             ",
+            "-n, --non-recursive           Do not execute primary tasks of child projects.   ",
+            "-p, --project-dir             Specifies the start dir for Gradle. Defaults to   ",
+            "                                current dir.                                    ",
+            "-q, --quiet                   Log errors only.                                  ",
+            "-r, --rebuild-cache           Rebuild the cache of compiled build scripts.      ",
+            "-s, --stacktrace              Print out the stacktrace also for user exceptions ",
+            "                                (e.g. compile error).                           ",
+            "-t, --tasks                   Show list of all available tasks and their        ",
+            "                                dependencies.                                   ",
+            "-u, --no-search-upward        Don't search in parent folders for a settings.    ",
+            "                                gradle file.                                    ",
+            "-v, --version                 Print version info.                               ",
+            "-x, --cache-off               No caching of compiled build scripts.             ",
             EMPTY );
     }
 
     @Test
     public void dateConverterShowsDatePattern() throws Exception {
-        parser.accepts( "date", "a date" ).withRequiredArg().withValuesConvertedBy(datePattern("MM/dd/yy"));
+        parser.accepts( "date", "a date" )
+            .withRequiredArg()
+            .withValuesConvertedBy( datePattern( "MM/dd/yy" ) );
 
         parser.printHelpOn( sink );
 
@@ -452,8 +445,9 @@ public class DefaultSettingsOptionParserHelpTest extends AbstractOptionParserFix
 
     @Test
     public void inetAddressConverterShowsType() throws Exception {
-        parser.accepts( "addr", "an internet address" ).withRequiredArg()
-                .withValuesConvertedBy(new InetAddressConverter());
+        parser.accepts( "addr", "an internet address" )
+            .withRequiredArg()
+            .withValuesConvertedBy( new InetAddressConverter() );
 
         parser.printHelpOn( sink );
 
@@ -659,22 +653,60 @@ public class DefaultSettingsOptionParserHelpTest extends AbstractOptionParserFix
     }
 
     @Test
-    public void fixForIssue56() throws IOException {
+    public void fixForIssue56() throws Exception {
         parser.accepts( "password", "Server Password" ).withRequiredArg().ofType( String.class );
         parser.accepts( "F", "Forward port mapping (ie: localhost:5900:localhost:5900)" ).withRequiredArg();
         parser.accepts( "R", "Reverse port mapping (ie: localhost:5900:localhost:5900)" ).withRequiredArg();
 
         parser.printHelpOn( sink );
 
+        assertHelpLines("" +
+            "Option      Description                                             ",
+            "------      -----------                                             ",
+            "-F          Forward port mapping (ie: localhost:5900:localhost:5900)",
+            "-R          Reverse port mapping (ie: localhost:5900:localhost:5900)",
+            "--password  Server Password                                         ",
+            EMPTY );
+    }
+
+    @Test
+    public void fixForIssue85() throws Exception {
+        parser.acceptsAll( asList( "?", "help" ), "Display this help text" ).forHelp();
+        parser.acceptsAll( asList( "c", "check-avail" ),
+            "Check Galileo homepage for available books, compare with known ones" );
+        parser.acceptsAll( asList( "d", "download-dir" ),
+            "Download directory for openbooks; must exist" )
+            .withRequiredArg().ofType( File.class ).defaultsTo( new File( "." ) );
+        parser.acceptsAll( asList( "l", "log-level" ),
+            "Log level (0=normal, 1=verbose, 2=debug, 3=trace" )
+            .withRequiredArg().ofType( int.class ).defaultsTo( 0 );
+        parser.acceptsAll( asList( "m", "check-md5" ),
+            "Download all known books without storing them, verifying their MD5 checksum (slow! >1 Gb download)" );
+        parser.acceptsAll( asList( "t", "threading" ),
+            "Threading mode (0=single, 1=multi); single is slower, but better for diagnostics)" )
+            .withRequiredArg().ofType( int.class ).defaultsTo( 1 );
+        parser.acceptsAll( asList( "w", "write-config" ),
+            "Write editable book list to config.xml, enabling you to update MD5 checksums or add new books" );
+
+        parser.printHelpOn( sink );
+
         assertHelpLines(
-                "Option      Description                         ",
-                "------      -----------                         ",
-                "-F          Forward port mapping (ie: localhost:",
-                "              5900:localhost:5900)              ",
-                "-R          Reverse port mapping (ie: localhost:",
-                "              5900:localhost:5900)              ",
-                "--password  Server Password                     ",
-                EMPTY );
+            "Option                     Description                                          ",
+            "------                     -----------                                          ",
+            "-?, --help                 Display this help text                               ",
+            "-c, --check-avail          Check Galileo homepage for available books, compare  ",
+            "                             with known ones                                    ",
+            "-d, --download-dir <File>  Download directory for openbooks; must exist         ",
+            "                             (default: .)                                       ",
+            "-l, --log-level <Integer>  Log level (0=normal, 1=verbose, 2=debug, 3=trace     ",
+            "                             (default: 0)                                       ",
+            "-m, --check-md5            Download all known books without storing them,       ",
+            "                             verifying their MD5 checksum (slow! >1 Gb download)",
+            "-t, --threading <Integer>  Threading mode (0=single, 1=multi); single is        ",
+            "                             slower, but better for diagnostics) (default: 1)   ",
+            "-w, --write-config         Write editable book list to config.xml, enabling you ",
+            "                             to update MD5 checksums or add new books           ",
+            EMPTY );
     }
 
     private void assertHelpLines( String... expectedLines ) {

--- a/src/test/java/joptsimple/internal/RowsTest.java
+++ b/src/test/java/joptsimple/internal/RowsTest.java
@@ -68,12 +68,11 @@ public class RowsTest {
         rows.add( "another left one", "another right one could be used here instead" );
 
         assertRows( rows,
-                "left one          right one for the",
-                "                    time we have   ",
-                "                    chosen         ",
-                "another left one  another right one",
-                "                    could be used  ",
-                "                    here instead   " );
+            "left one          right one for the    ",
+            "                    time we have chosen",
+            "another left one  another right one    ",
+            "                    could be used here ",
+            "                    instead            " );
     }
 
     private void assertRows( Rows rows, String... expected ) {


### PR DESCRIPTION
The description column should consume as much horizontal space as it can,
up to the overall width. Correcting the behavior amounted to correcting the
implementation of a private method "descriptionWidth()" in internal class
Rows.