### PR TITLE
Optionally reject abbreviations of long options

### DIFF
--- a/src/main/java/joptsimple/OptionParser.java
+++ b/src/main/java/joptsimple/OptionParser.java
@@ -32,6 +32,8 @@ import java.io.Writer;
 import java.util.*;
 
 import joptsimple.internal.AbbreviationMap;
+import joptsimple.internal.SimpleOptionNameMap;
+import joptsimple.internal.OptionNameMap;
 import joptsimple.util.KeyValuePair;
 
 import static java.util.Collections.*;
@@ -187,7 +189,7 @@ import static joptsimple.ParserRules.*;
  * @see <a href="http://www.gnu.org/software/libc/manual">The GNU C Library</a>
  */
 public class OptionParser implements OptionDeclarer {
-    private final AbbreviationMap<AbstractOptionSpec<?>> recognizedOptions;
+    private final OptionNameMap<AbstractOptionSpec<?>> recognizedOptions;
     private final ArrayList<AbstractOptionSpec<?>> trainingOrder;
     private final Map<List<String>, Set<OptionSpec<?>>> requiredIf;
     private final Map<List<String>, Set<OptionSpec<?>>> requiredUnless;
@@ -204,7 +206,16 @@ public class OptionParser implements OptionDeclarer {
      * behavior.
      */
     public OptionParser() {
-        recognizedOptions = new AbbreviationMap<>();
+        this(true);
+    }
+
+    /**
+     * Creates an option parser that initially recognizes no options, and does not exhibit "POSIX-ly correct"
+     * behavior
+     * @param allowAbbreviations should unambiguous abbreviations of long options be recognized by the parser
+     */
+    public OptionParser(boolean allowAbbreviations) {
+
         trainingOrder = new ArrayList<>();
         requiredIf = new HashMap<>();
         requiredUnless = new HashMap<>();
@@ -212,8 +223,12 @@ public class OptionParser implements OptionDeclarer {
         availableUnless = new HashMap<>();
         state = moreOptions( false );
 
+        recognizedOptions = allowAbbreviations ? new AbbreviationMap<AbstractOptionSpec<?>>()
+                : new SimpleOptionNameMap<AbstractOptionSpec<?>>();
+
         recognize( new NonOptionArgumentSpec<String>() );
     }
+
 
     /**
      * Creates an option parser and configures it to recognize the short options specified in the given string.

--- a/src/main/java/joptsimple/internal/AbbreviationMap.java
+++ b/src/main/java/joptsimple/internal/AbbreviationMap.java
@@ -57,7 +57,7 @@ import java.util.TreeMap;
  * @see <a href="http://perldoc.perl.org/Text/Abbrev.html">Perl's Text::Abbrev module</a>
  * @see <a href="https://en.wikipedia.org/wiki/Radix_tree">Radix tree</a>
  */
-public class AbbreviationMap<V> {
+public class AbbreviationMap<V> implements OptionNameMap<V> {
     private final Map<Character, AbbreviationMap<V>> children = new TreeMap<>();
 
     private String key;
@@ -72,7 +72,8 @@ public class AbbreviationMap<V> {
      * @return {@code true} if {@code key} is present in the map
      * @throws NullPointerException if {@code key} is {@code null}
      */
-    public boolean contains( String aKey ) {
+    @Override
+    public boolean contains(String aKey) {
         return get( aKey ) != null;
     }
 
@@ -85,7 +86,8 @@ public class AbbreviationMap<V> {
      * such value or {@code aKey} is not a unique abbreviation of a key in the map
      * @throws NullPointerException if {@code aKey} is {@code null}
      */
-    public V get( String aKey ) {
+    @Override
+    public V get(String aKey) {
         char[] chars = charsOf( aKey );
 
         AbbreviationMap<V> child = this;
@@ -107,7 +109,8 @@ public class AbbreviationMap<V> {
      * @throws NullPointerException if {@code aKey} or {@code newValue} is {@code null}
      * @throws IllegalArgumentException if {@code aKey} is a zero-length string
      */
-    public void put( String aKey, V newValue ) {
+    @Override
+    public void put(String aKey, V newValue) {
         if ( newValue == null )
             throw new NullPointerException();
         if ( aKey.length() == 0 )
@@ -126,7 +129,8 @@ public class AbbreviationMap<V> {
      * @throws NullPointerException if {@code keys} or {@code newValue} is {@code null}
      * @throws IllegalArgumentException if any of {@code keys} is a zero-length string
      */
-    public void putAll( Iterable<String> keys, V newValue ) {
+    @Override
+    public void putAll(Iterable<String> keys, V newValue) {
         for ( String each : keys )
             put( each, newValue );
     }
@@ -164,7 +168,8 @@ public class AbbreviationMap<V> {
      * @throws NullPointerException if {@code aKey} is {@code null}
      * @throws IllegalArgumentException if {@code aKey} is a zero-length string
      */
-    public void remove( String aKey ) {
+    @Override
+    public void remove(String aKey) {
         if ( aKey.length() == 0 )
             throw new IllegalArgumentException();
 
@@ -214,6 +219,7 @@ public class AbbreviationMap<V> {
      *
      * @return a Java map corresponding to this abbreviation map
      */
+    @Override
     public Map<String, V> toJavaUtilMap() {
         Map<String, V> mappings = new TreeMap<>();
         addToMappings( mappings );

--- a/src/main/java/joptsimple/internal/OptionNameMap.java
+++ b/src/main/java/joptsimple/internal/OptionNameMap.java
@@ -1,0 +1,21 @@
+package joptsimple.internal;
+
+import java.util.Map;
+
+/**
+ * Map like interface for storing String -> V pairs
+ * @param <V>
+ */
+public interface OptionNameMap<V> {
+    boolean contains(String aKey);
+
+    V get(String aKey);
+
+    void put(String aKey, V newValue);
+
+    void putAll(Iterable<String> keys, V newValue);
+
+    void remove(String aKey);
+
+    Map<String, V> toJavaUtilMap();
+}

--- a/src/main/java/joptsimple/internal/SimpleOptionNameMap.java
+++ b/src/main/java/joptsimple/internal/SimpleOptionNameMap.java
@@ -1,0 +1,43 @@
+package joptsimple.internal;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * <p>An {@code OptionNameMap} which wraps a and behaves like {@code HashMap}.</p>
+ */
+public class SimpleOptionNameMap<V> implements OptionNameMap<V>{
+
+    private final Map<String, V> map = new HashMap<>();
+
+    @Override
+    public boolean contains(String aKey) {
+        return map.containsKey(aKey);
+    }
+
+    @Override
+    public V get(String aKey) {
+        return map.get(aKey);
+    }
+
+    @Override
+    public void put(String aKey, V newValue) {
+        map.put(aKey, newValue);
+    }
+
+    @Override
+    public void putAll(Iterable<String> keys, V newValue) {
+        for( String key : keys)
+            map.put(key, newValue);
+    }
+
+    @Override
+    public void remove(String aKey) {
+        map.remove(aKey);
+    }
+
+    @Override
+    public Map<String, V> toJavaUtilMap() {
+        return new HashMap<>(map);
+    }
+}

--- a/src/test/java/joptsimple/OptionParserTest.java
+++ b/src/test/java/joptsimple/OptionParserTest.java
@@ -305,4 +305,16 @@ public class OptionParserTest extends AbstractOptionParserFixture {
 
         parser.parse();
     }
+
+    @Test
+    public void abbreviationsCanBeDisallowed(){
+        OptionParser parser = new OptionParser(false);
+        parser.accepts("abbreviatable");
+
+        parser.parse("--abbreviatable");
+
+        thrown.expect(UnrecognizedOptionException.class);
+
+        parser.parse("--abb");
+    }
 }

--- a/src/test/java/joptsimple/internal/SimpleOptionNameMapTest.java
+++ b/src/test/java/joptsimple/internal/SimpleOptionNameMapTest.java
@@ -1,0 +1,61 @@
+package joptsimple.internal;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class SimpleOptionNameMapTest {
+    private static final Integer VALUE = 1;
+    private static final String KEY = "someKey";
+    private static final String KEY2 = "someOtherKey";
+
+    @Test
+    public void testPutAndContains(){
+        final SimpleOptionNameMap<Integer> map = new SimpleOptionNameMap<>();
+        assertFalse(map.contains(KEY));
+        map.put(KEY, 1);
+        assertTrue(map.contains(KEY));
+
+    }
+
+    @Test
+    public void testGet() throws Exception {
+        final SimpleOptionNameMap<Integer> map = new SimpleOptionNameMap<>();
+        assertNull(map.get(KEY));
+        map.put(KEY, VALUE);
+        assertEquals(map.get(KEY), VALUE);
+    }
+
+    @Test
+    public void testPutAll() throws Exception {
+        final SimpleOptionNameMap<Integer> map = new SimpleOptionNameMap<>();
+        List<String> keys = Arrays.asList(KEY, KEY2);
+        map.putAll(keys, VALUE);
+        assertEquals(map.get(KEY), VALUE);
+        assertEquals(map.get(KEY2), VALUE);
+    }
+
+    @Test
+    public void testRemove() throws Exception {
+        final SimpleOptionNameMap<Integer> map = new SimpleOptionNameMap<>();
+        map.put(KEY, 1);
+        assertTrue(map.contains(KEY));
+        map.remove(KEY);
+        assertFalse(map.contains(KEY));
+    }
+
+    @Test
+    public void testToJavaUtilMap() throws Exception {
+        final SimpleOptionNameMap<Integer> map = new SimpleOptionNameMap<>();
+        map.put(KEY, VALUE);
+
+        final Map<String, Integer> javaUtilMap = map.toJavaUtilMap();
+        assertEquals(javaUtilMap.get(KEY), VALUE);
+        assertEquals(javaUtilMap.size(), 1);
+
+    }
+}


### PR DESCRIPTION
Added the option to configure an ObjectParser so that it does not accept abbreviations for options
  Extracted a new ObjectNameMap interface from AbbreviationMap
  Added SimpleObjectNameMap which implements ObjectNameMap and behaves like a standard map
  Added a new constructor to ObjectParser that allow configuring an ObjectParser that does not accept abbreviations.

Resolves #88 