### PR TITLE
Use getMethod instead of getDeclaredMethod for valueOf reflection

### DIFF
--- a/src/main/java/joptsimple/internal/Reflection.java
+++ b/src/main/java/joptsimple/internal/Reflection.java
@@ -68,7 +68,7 @@ public final class Reflection {
 
     private static <V> ValueConverter<V> valueOfConverter( Class<V> clazz ) {
         try {
-            Method valueOf = clazz.getDeclaredMethod( "valueOf", String.class );
+            Method valueOf = clazz.getMethod( "valueOf", String.class );
             if ( meetsConverterRequirements( valueOf, clazz ) )
                 return new MethodInvokingValueConverter<>( valueOf, clazz );
 


### PR DESCRIPTION
Using getDeclaredMethod requires the privilege accessDeclaredMembers
when running under a SecurityManager. However, this returns private,
protected and package private methods as well as public, while static
valueOf functions are already required to be public. Since public
is all that is needed, getMethod works fine, and doesn't require any
special privileges.