### PR TITLE
Make AbstractOptionSpec public for Kotlin

### DIFF
--- a/src/main/java/joptsimple/AbstractOptionSpec.java
+++ b/src/main/java/joptsimple/AbstractOptionSpec.java
@@ -39,16 +39,16 @@ import static joptsimple.internal.Strings.*;
  * @param <V> represents the type of the arguments this option accepts
  * @author <a href="mailto:pholser@alumni.rice.edu">Paul Holser</a>
  */
-abstract class AbstractOptionSpec<V> implements OptionSpec<V>, OptionDescriptor {
+public abstract class AbstractOptionSpec<V> implements OptionSpec<V>, OptionDescriptor {
     private final List<String> options = new ArrayList<>();
     private final String description;
     private boolean forHelp;
 
-    protected AbstractOptionSpec( String option ) {
+    AbstractOptionSpec( String option ) {
         this( singletonList( option ), EMPTY );
     }
 
-    protected AbstractOptionSpec( List<String> options, String description ) {
+    AbstractOptionSpec( List<String> options, String description ) {
         arrangeOptions( options );
 
         this.description = description;


### PR DESCRIPTION
Kotlin does not allow to use classes in package scope
even when they have public methods.
When a class in package scope has public methods
these bleed into the public space anyway.
So make the class public but let the constructors
be package protected so it may only be instantiated
from within the package.