### PR TITLE
For #96: "String" as an option arg type indicator

### DIFF
--- a/src/main/java/joptsimple/BuiltinHelpFormatter.java
+++ b/src/main/java/joptsimple/BuiltinHelpFormatter.java
@@ -414,8 +414,12 @@ public class BuiltinHelpFormatter implements HelpFormatter {
     protected void maybeAppendOptionInfo( StringBuilder buffer, OptionDescriptor descriptor ) {
         String indicator = extractTypeIndicator( descriptor );
         String description = descriptor.argumentDescription();
-        if ( indicator != null || !isNullOrEmpty( description ) )
+        if ( descriptor.acceptsArguments()
+            || !isNullOrEmpty( description )
+            || descriptor.representsNonOptions() ) {
+
             appendOptionHelp( buffer, indicator, description, descriptor.requiresArgument() );
+        }
     }
 
     /**
@@ -424,7 +428,7 @@ public class BuiltinHelpFormatter implements HelpFormatter {
      *
      * <p>This implementation asks for the {@link OptionDescriptor#argumentTypeIndicator()} of the given
      * descriptor, and if it is present and not {@code "java.lang.String"}, parses it as a fully qualified
-     * class name and returns the base name of that class; otherwise returns {@code null}.</p>
+     * class name and returns the base name of that class; otherwise returns {@code "String"}.</p>
      *
      * @param descriptor a descriptor for a configured option of a parser
      * @return type indicator text
@@ -435,7 +439,7 @@ public class BuiltinHelpFormatter implements HelpFormatter {
         if ( !isNullOrEmpty( indicator ) && !String.class.getName().equals( indicator ) )
             return shortNameOf( indicator );
 
-        return null;
+        return "String";
     }
 
     /**

--- a/src/test/java/joptsimple/ConfigurableOptionParserHelpTest.java
+++ b/src/test/java/joptsimple/ConfigurableOptionParserHelpTest.java
@@ -108,9 +108,9 @@ public class ConfigurableOptionParserHelpTest extends AbstractOptionParserFixtur
         parser.printHelpOn( sink );
 
         assertHelpLines(
-            "Option   Description",
-            "------   -----------",
-            "-a                  ",
+            "Option        Description",
+            "------        -----------",
+            "-a <String>              ",
             EMPTY );
     }
 
@@ -134,9 +134,9 @@ public class ConfigurableOptionParserHelpTest extends AbstractOptionParserFixtur
         parser.printHelpOn( sink );
 
         assertHelpLines(
-            "Option           Description        ",
-            "------           -----------        ",
-            "-a <numerical>   some value you need",
+            "Option                   Description        ",
+            "------                   -----------        ",
+            "-a <String: numerical>   some value you need",
             EMPTY );
     }
 
@@ -161,9 +161,9 @@ public class ConfigurableOptionParserHelpTest extends AbstractOptionParserFixtur
         parser.printHelpOn( sink );
 
         assertHelpLines(
-            "Option        Description",
-            "------        -----------",
-            "--threshold              ",
+            "Option                 Description",
+            "------                 -----------",
+            "--threshold [String]              ",
             EMPTY );
     }
 
@@ -187,9 +187,9 @@ public class ConfigurableOptionParserHelpTest extends AbstractOptionParserFixtur
         parser.printHelpOn( sink );
 
         assertHelpLines(
-            "Option                           Description        ",
-            "------                           -----------        ",
-            "--threshold [positive integer]   some value you need",
+            "Option                                   Description        ",
+            "------                                   -----------        ",
+            "--threshold [String: positive integer]   some value you need",
             EMPTY );
     }
 
@@ -214,9 +214,9 @@ public class ConfigurableOptionParserHelpTest extends AbstractOptionParserFixtur
         parser.printHelpOn( sink );
 
         assertHelpLines(
-            "Option           Description                     ",
-            "------           -----------                     ",
-            "-W <opt=value>   Alternative form of long options",
+            "Option                   Description                     ",
+            "------                   -----------                     ",
+            "-W <String: opt=value>   Alternative form of long options",
             EMPTY );
     }
 
@@ -337,32 +337,33 @@ public class ConfigurableOptionParserHelpTest extends AbstractOptionParserFixtur
         parser.printHelpOn( sink );
 
         assertHelpLines(
-            "Option                         Description                                                                          ",
-            "------                         -----------                                                                          ",
-            "-?, -h                         Shows this help message.                                                             ",
-            "-B, --bootstrap-debug          Specify a text to be logged at the beginning (e.g. used by Gradle's bootstrap class).",
-            "-D, --systemprop               Set system property of the JVM (e.g. -Dmyprop=myvalue).                              ",
-            "-I, --no-imports               Disable usage of default imports for build script files.                             ",
-            "-P, --projectprop              Set project property for the build script (e.g. -Pmyprop=myvalue).                   ",
-            "-S                             Don't trigger a System.exit(0) for normal termination. Used for Gradle's internal    ",
-            "                                 testing.                                                                           ",
-            "-b, --buildfile                Specifies the build file name (also for subprojects). Defaults to build.gradle.      ",
-            "-d, --debug                    Log in debug mode (includes normal stacktrace).                                      ",
-            "-e, --embedded                 Specify an embedded build script.                                                    ",
-            "-f, --full-stacktrace          Print out the full (very verbose) stacktrace for any exceptions.                     ",
-            "-g, --gradle-user-home         Specifies the gradle user home dir.                                                  ",
-            "-i, --ivy-quiet                Set Ivy log level to quiet.                                                          ",
-            "-j, --ivy-debug                Set Ivy log level to debug (very verbose).                                           ",
-            "-l, --plugin-properties-file   Specifies the plugin.properties file.                                                ",
-            "-n, --non-recursive            Do not execute primary tasks of child projects.                                      ",
-            "-p, --project-dir              Specifies the start dir for Gradle. Defaults to current dir.                         ",
-            "-q, --quiet                    Log errors only.                                                                     ",
-            "-r, --rebuild-cache            Rebuild the cache of compiled build scripts.                                         ",
-            "-s, --stacktrace               Print out the stacktrace also for user exceptions (e.g. compile error).              ",
-            "-t, --tasks                    Show list of all available tasks and their dependencies.                             ",
-            "-u, --no-search-upward         Don't search in parent folders for a settings.gradle file.                           ",
-            "-v, --version                  Print version info.                                                                  ",
-            "-x, --cache-off                No caching of compiled build scripts.                                                ",
+            "Option                                  Description                                                                    ",
+            "------                                  -----------                                                                    ",
+            "-?, -h                                  Shows this help message.                                                       ",
+            "-B, --bootstrap-debug <String>          Specify a text to be logged at the beginning (e.g. used by Gradle's bootstrap  ",
+            "                                          class).                                                                      ",
+            "-D, --systemprop <String>               Set system property of the JVM (e.g. -Dmyprop=myvalue).                        ",
+            "-I, --no-imports                        Disable usage of default imports for build script files.                       ",
+            "-P, --projectprop <String>              Set project property for the build script (e.g. -Pmyprop=myvalue).             ",
+            "-S                                      Don't trigger a System.exit(0) for normal termination. Used for Gradle's       ",
+            "                                          internal testing.                                                            ",
+            "-b, --buildfile <String>                Specifies the build file name (also for subprojects). Defaults to build.gradle.",
+            "-d, --debug                             Log in debug mode (includes normal stacktrace).                                ",
+            "-e, --embedded <String>                 Specify an embedded build script.                                              ",
+            "-f, --full-stacktrace                   Print out the full (very verbose) stacktrace for any exceptions.               ",
+            "-g, --gradle-user-home <String>         Specifies the gradle user home dir.                                            ",
+            "-i, --ivy-quiet                         Set Ivy log level to quiet.                                                    ",
+            "-j, --ivy-debug                         Set Ivy log level to debug (very verbose).                                     ",
+            "-l, --plugin-properties-file <String>   Specifies the plugin.properties file.                                          ",
+            "-n, --non-recursive                     Do not execute primary tasks of child projects.                                ",
+            "-p, --project-dir <String>              Specifies the start dir for Gradle. Defaults to current dir.                   ",
+            "-q, --quiet                             Log errors only.                                                               ",
+            "-r, --rebuild-cache                     Rebuild the cache of compiled build scripts.                                   ",
+            "-s, --stacktrace                        Print out the stacktrace also for user exceptions (e.g. compile error).        ",
+            "-t, --tasks                             Show list of all available tasks and their dependencies.                       ",
+            "-u, --no-search-upward                  Don't search in parent folders for a settings.gradle file.                     ",
+            "-v, --version                           Print version info.                                                            ",
+            "-x, --cache-off                         No caching of compiled build scripts.                                          ",
             EMPTY );
     }
 
@@ -417,9 +418,9 @@ public class ConfigurableOptionParserHelpTest extends AbstractOptionParserFixtur
         parser.printHelpOn( sink );
 
         assertHelpLines(
-            "Option   Description   ",
-            "------   -----------   ",
-            "-a       (default: boo)",
+            "Option        Description   ",
+            "------        -----------   ",
+            "-a <String>   (default: boo)",
             EMPTY );
     }
 
@@ -473,7 +474,7 @@ public class ConfigurableOptionParserHelpTest extends AbstractOptionParserFixtur
         assertHelpLines(
             "Option (* = required)   Description",
             "---------------------   -----------",
-            "* -e                               ",
+            "* -e <String>                      ",
             EMPTY );
     }
 

--- a/src/test/java/joptsimple/DefaultSettingsOptionParserHelpTest.java
+++ b/src/test/java/joptsimple/DefaultSettingsOptionParserHelpTest.java
@@ -128,9 +128,9 @@ public class DefaultSettingsOptionParserHelpTest extends AbstractOptionParserFix
         parser.printHelpOn( sink );
 
         assertHelpLines(
-            "Option  Description",
-            "------  -----------",
-            "-a                 ",
+            "Option       Description",
+            "------       -----------",
+            "-a <String>             ",
             EMPTY );
     }
 
@@ -154,9 +154,9 @@ public class DefaultSettingsOptionParserHelpTest extends AbstractOptionParserFix
         parser.printHelpOn( sink );
 
         assertHelpLines(
-            "Option          Description        ",
-            "------          -----------        ",
-            "-a <numerical>  some value you need",
+            "Option                  Description        ",
+            "------                  -----------        ",
+            "-a <String: numerical>  some value you need",
             EMPTY );
     }
 
@@ -181,9 +181,9 @@ public class DefaultSettingsOptionParserHelpTest extends AbstractOptionParserFix
         parser.printHelpOn( sink );
 
         assertHelpLines(
-            "Option       Description",
-            "------       -----------",
-            "--threshold             ",
+            "Option                Description",
+            "------                -----------",
+            "--threshold [String]             ",
             EMPTY );
     }
 
@@ -207,9 +207,9 @@ public class DefaultSettingsOptionParserHelpTest extends AbstractOptionParserFix
         parser.printHelpOn( sink );
 
         assertHelpLines(
-            "Option                          Description        ",
-            "------                          -----------        ",
-            "--threshold [positive integer]  some value you need",
+            "Option                                  Description        ",
+            "------                                  -----------        ",
+            "--threshold [String: positive integer]  some value you need",
             EMPTY );
     }
 
@@ -234,9 +234,9 @@ public class DefaultSettingsOptionParserHelpTest extends AbstractOptionParserFix
         parser.printHelpOn( sink );
 
         assertHelpLines(
-            "Option          Description                     ",
-            "------          -----------                     ",
-            "-W <opt=value>  Alternative form of long options",
+            "Option                  Description                     ",
+            "------                  -----------                     ",
+            "-W <String: opt=value>  Alternative form of long options",
             EMPTY );
     }
 
@@ -383,49 +383,55 @@ public class DefaultSettingsOptionParserHelpTest extends AbstractOptionParserFix
             "Specify an embedded build script." )
             .withRequiredArg().ofType( String.class );
         parser.acceptsAll( asList( "B", "bootstrap-debug" ),
-            "Specify a text to be logged at the beginning (e.g. used by Gradle's bootstrap class." )
+            "Specify a text to be logged at the beginning (e.g. used by Gradle's bootstrap class)." )
             .withRequiredArg().ofType( String.class );
         parser.acceptsAll( asList( "h", "?" ), "Shows this help message" ).forHelp();
 
         parser.printHelpOn( sink );
 
         assertHelpLines(
-            "Option                        Description                                       ",
-            "------                        -----------                                       ",
-            "-?, -h                        Shows this help message                           ",
-            "-B, --bootstrap-debug         Specify a text to be logged at the beginning (e.  ",
-            "                                g. used by Gradle's bootstrap class.            ",
-            "-D, --systemprop              Set system property of the JVM (e.g. -            ",
-            "                                Dmyprop=myvalue).                               ",
-            "-I, --no-imports              Disable usage of default imports for build script ",
-            "                                files.                                          ",
-            "-P, --projectprop             Set project property for the build script (e.g. - ",
-            "                                Pmyprop=myvalue).                               ",
-            "-S                            Don't trigger a System.exit(0) for normal         ",
-            "                                termination. Used for Gradle's internal testing.",
-            "-b, --buildfile               Specifies the build file name (also for           ",
-            "                                subprojects). Defaults to build.gradle.         ",
-            "-d, --debug                   Log in debug mode (includes normal stacktrace).   ",
-            "-e, --embedded                Specify an embedded build script.                 ",
-            "-f, --full-stacktrace         Print out the full (very verbose) stacktrace for  ",
-            "                                any exceptions.                                 ",
-            "-g, --gradle-user-home        Specifies the gradle user home dir.               ",
-            "-i, --ivy-quiet               Set Ivy log level to quiet.                       ",
-            "-j, --ivy-debug               Set Ivy log level to debug (very verbose).        ",
-            "-l, --plugin-properties-file  Specifies the plugin.properties file.             ",
-            "-n, --non-recursive           Do not execute primary tasks of child projects.   ",
-            "-p, --project-dir             Specifies the start dir for Gradle. Defaults to   ",
-            "                                current dir.                                    ",
-            "-q, --quiet                   Log errors only.                                  ",
-            "-r, --rebuild-cache           Rebuild the cache of compiled build scripts.      ",
-            "-s, --stacktrace              Print out the stacktrace also for user exceptions ",
-            "                                (e.g. compile error).                           ",
-            "-t, --tasks                   Show list of all available tasks and their        ",
-            "                                dependencies.                                   ",
-            "-u, --no-search-upward        Don't search in parent folders for a settings.    ",
-            "                                gradle file.                                    ",
-            "-v, --version                 Print version info.                               ",
-            "-x, --cache-off               No caching of compiled build scripts.             ",
+            "Option                                 Description                              ",
+            "------                                 -----------                              ",
+            "-?, -h                                 Shows this help message                  ",
+            "-B, --bootstrap-debug <String>         Specify a text to be logged at the       ",
+            "                                         beginning (e.g. used by Gradle's       ",
+            "                                         bootstrap class).                      ",
+            "-D, --systemprop <String>              Set system property of the JVM (e.g. -   ",
+            "                                         Dmyprop=myvalue).                      ",
+            "-I, --no-imports                       Disable usage of default imports for     ",
+            "                                         build script files.                    ",
+            "-P, --projectprop <String>             Set project property for the build       ",
+            "                                         script (e.g. -Pmyprop=myvalue).        ",
+            "-S                                     Don't trigger a System.exit(0) for       ",
+            "                                         normal termination. Used for Gradle's  ",
+            "                                         internal testing.                      ",
+            "-b, --buildfile <String>               Specifies the build file name (also for  ",
+            "                                         subprojects). Defaults to build.gradle.",
+            "-d, --debug                            Log in debug mode (includes normal       ",
+            "                                         stacktrace).                           ",
+            "-e, --embedded <String>                Specify an embedded build script.        ",
+            "-f, --full-stacktrace                  Print out the full (very verbose)        ",
+            "                                         stacktrace for any exceptions.         ",
+            "-g, --gradle-user-home <String>        Specifies the gradle user home dir.      ",
+            "-i, --ivy-quiet                        Set Ivy log level to quiet.              ",
+            "-j, --ivy-debug                        Set Ivy log level to debug (very         ",
+            "                                         verbose).                              ",
+            "-l, --plugin-properties-file <String>  Specifies the plugin.properties file.    ",
+            "-n, --non-recursive                    Do not execute primary tasks of child    ",
+            "                                         projects.                              ",
+            "-p, --project-dir <String>             Specifies the start dir for Gradle.      ",
+            "                                         Defaults to current dir.               ",
+            "-q, --quiet                            Log errors only.                         ",
+            "-r, --rebuild-cache                    Rebuild the cache of compiled build      ",
+            "                                         scripts.                               ",
+            "-s, --stacktrace                       Print out the stacktrace also for user   ",
+            "                                         exceptions (e.g. compile error).       ",
+            "-t, --tasks                            Show list of all available tasks and     ",
+            "                                         their dependencies.                    ",
+            "-u, --no-search-upward                 Don't search in parent folders for a     ",
+            "                                         settings.gradle file.                  ",
+            "-v, --version                          Print version info.                      ",
+            "-x, --cache-off                        No caching of compiled build scripts.    ",
             EMPTY );
     }
 
@@ -499,9 +505,9 @@ public class DefaultSettingsOptionParserHelpTest extends AbstractOptionParserFix
         parser.printHelpOn( sink );
 
         assertHelpLines(
-            "Option  Description   ",
-            "------  -----------   ",
-            "-a      (default: boo)",
+            "Option       Description   ",
+            "------       -----------   ",
+            "-a <String>  (default: boo)",
             EMPTY );
     }
 
@@ -555,7 +561,7 @@ public class DefaultSettingsOptionParserHelpTest extends AbstractOptionParserFix
         assertHelpLines(
             "Option (* = required)  Description",
             "---------------------  -----------",
-            "* -e                              ",
+            "* -e <String>                     ",
             EMPTY );
     }
 
@@ -567,7 +573,7 @@ public class DefaultSettingsOptionParserHelpTest extends AbstractOptionParserFix
 
         assertHelpLines(
             "Non-option arguments:",
-            "stuff                ",
+            "[String] -- stuff    ",
             EMPTY,
             "No options specified  ",
             EMPTY );
@@ -595,7 +601,7 @@ public class DefaultSettingsOptionParserHelpTest extends AbstractOptionParserFix
 
         assertHelpLines(
             "Non-option arguments:",
-            "[files]              ",
+            "[String: files]      ",
             EMPTY,
             "No options specified  ",
             EMPTY );
@@ -677,12 +683,12 @@ public class DefaultSettingsOptionParserHelpTest extends AbstractOptionParserFix
 
         parser.printHelpOn( sink );
 
-        assertHelpLines("" +
-            "Option      Description                                             ",
-            "------      -----------                                             ",
-            "-F          Forward port mapping (ie: localhost:5900:localhost:5900)",
-            "-R          Reverse port mapping (ie: localhost:5900:localhost:5900)",
-            "--password  Server Password                                         ",
+        assertHelpLines(
+            "Option               Description                                             ",
+            "------               -----------                                             ",
+            "-F <String>          Forward port mapping (ie: localhost:5900:localhost:5900)",
+            "-R <String>          Reverse port mapping (ie: localhost:5900:localhost:5900)",
+            "--password <String>  Server Password                                         ",
             EMPTY );
     }
 


### PR DESCRIPTION
Leaving out "String" as an option arg type indicator in the default help
output for an option parser was confusing for some.