### PR TITLE
For #101, support Optional on valueOf()

### DIFF
--- a/src/main/java/joptsimple/AbstractOptionSpec.java
+++ b/src/main/java/joptsimple/AbstractOptionSpec.java
@@ -27,6 +27,7 @@ package joptsimple;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static java.util.Collections.*;
 
@@ -67,6 +68,11 @@ public abstract class AbstractOptionSpec<V> implements OptionSpec<V>, OptionDesc
     @Override
     public final V value( OptionSet detectedOptions ) {
         return detectedOptions.valueOf( this );
+    }
+
+    @Override
+    public final Optional<V> valueOptional( OptionSet detectedOptions ) {
+        return Optional.ofNullable( value( detectedOptions ) );
     }
 
     @Override

--- a/src/main/java/joptsimple/OptionSet.java
+++ b/src/main/java/joptsimple/OptionSet.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static java.util.Collections.*;
 import static java.util.Objects.*;
@@ -154,6 +155,24 @@ public class OptionSet {
     }
 
     /**
+     * Gives the argument associated with the given option, as an {@link Optional}.
+     * If the option was given an argument type, the argument will take on that type;
+     * otherwise, it will be a {@link String}.
+     *
+     * <p>Specifying a {@linkplain ArgumentAcceptingOptionSpec#defaultsTo(Object, Object[]) default argument value}
+     * for an option will cause this method to return that default value even if the option was not detected on the
+     * command line, or if the option can take an optional argument but did not have one on the command line.</p>
+     *
+     * @param option the option to search for
+     * @return the argument of the given option as an {@code Optional}
+     * @throws NullPointerException if {@code option} is {@code null}
+     * @throws OptionException if more than one argument was detected for the option
+     */
+    public Optional<Object> valueOfOptional( String option ) {
+        return Optional.ofNullable( valueOf( option ) );
+    }
+
+    /**
      * Gives the argument associated with the given option.
      *
      * <p>This method recognizes only instances of options returned from the fluent interface methods.</p>
@@ -178,6 +197,22 @@ public class OptionSet {
             default:
                 throw new MultipleArgumentsForOptionException( option );
         }
+    }
+
+    /**
+     * Gives the argument associated with the given option as an {@link Optional}.
+     *
+     * <p>This method recognizes only instances of options returned from the fluent interface methods.</p>
+     *
+     * @param <V> represents the type of the arguments the given option accepts
+     * @param option the option to search for
+     * @return the argument of the given option as an {@code Optional}
+     * @throws OptionException if more than one argument was detected for the option
+     * @throws NullPointerException if {@code option} is {@code null}
+     * @throws ClassCastException if the arguments of this option are not of the expected type
+     */
+    public <V> Optional<V> valueOfOptional( OptionSpec<V> option ) {
+        return Optional.ofNullable( valueOf( option ) );
     }
 
     /**

--- a/src/main/java/joptsimple/OptionSpec.java
+++ b/src/main/java/joptsimple/OptionSpec.java
@@ -26,6 +26,7 @@
 package joptsimple;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Describes options that an option parser recognizes.
@@ -81,6 +82,25 @@ public interface OptionSpec<V> {
      * @see OptionSet#valueOf(OptionSpec)
      */
     V value( OptionSet detectedOptions );
+
+    /**
+     * Gives the argument associated with the given option in the given set of detected options
+     * as an {@link Optional}.
+     *
+     * <p>Specifying a {@linkplain ArgumentAcceptingOptionSpec#defaultsTo(Object, Object[]) default argument value}
+     * for this option will cause this method to return that default value even if this option was not detected on the
+     * command line, or if this option can take an optional argument but did not have one on the command line.</p>
+     *
+     * @param detectedOptions the detected options to search in
+     * @return the argument of the this option as an {@code Optional}
+     * @throws OptionException if more than one argument was detected for the option
+     * @throws NullPointerException if {@code detectedOptions} is {@code null}
+     * @throws ClassCastException if the arguments of this option are not of the expected type
+     * @see OptionSet#valueOf(OptionSpec)
+     */
+    default Optional<V> valueOptional( OptionSet detectedOptions ) {
+        return Optional.ofNullable( value( detectedOptions ) );
+    }
 
     /**
      * @return the string representations of this option

--- a/src/site/apt/changes.apt
+++ b/src/site/apt/changes.apt
@@ -14,6 +14,9 @@ Changes in version 6.0
       <<<OptionDescriptor.converter()>>> to display the default values in a manner
       other than their <<<toString()>>> representations.
 
+    * Resolved {{{https://github.com/pholser/jopt-simple/issues/101} gh-101}} by
+      adding <<<OptionSet.valueOfOptional()>>> and <<<OptionSpec.valueOptional()>>>.
+
 Changes in version 5.0.3
 
     * Resolved {{{https://github.com/pholser/jopt-simple/issues/96} gh-96}} so that

--- a/src/test/java/joptsimple/AbstractOptionSpecFixture.java
+++ b/src/test/java/joptsimple/AbstractOptionSpecFixture.java
@@ -47,12 +47,17 @@ public abstract class AbstractOptionSpecFixture extends EqualsHashCodeTestSuppor
     protected abstract AbstractOptionSpec<?> createNotEqualOptionSpecInstance();
 
     @Test( expected = NullPointerException.class )
-    public final void testValuesWithNullOptionSet() {
+    public final void valuesWithNullOptionSet() {
         createEqualOptionSpecInstance().values( null );
     }
 
     @Test( expected = NullPointerException.class )
-    public final void testValueWithNullOptionSet() {
+    public final void valueWithNullOptionSet() {
         createNotEqualOptionSpecInstance().value( null );
+    }
+
+    @Test( expected = NullPointerException.class )
+    public final void valueOptionalWithNullOptionSet() {
+        createNotEqualOptionSpecInstance().valueOptional( null );
     }
 }

--- a/src/test/java/joptsimple/EmptyOptionSetTest.java
+++ b/src/test/java/joptsimple/EmptyOptionSetTest.java
@@ -25,6 +25,8 @@
 
 package joptsimple;
 
+import java.util.Optional;
+
 import static java.util.Collections.*;
 
 import org.junit.Before;
@@ -50,6 +52,11 @@ public class EmptyOptionSetTest {
     }
 
     @Test
+    public void valueOfOptional() {
+        assertEquals( Optional.empty(), empty.valueOfOptional( "a" ) );
+    }
+
+    @Test
     public void valuesOf() {
         assertEquals( emptyList(), empty.valuesOf( "a" ) );
     }
@@ -67,6 +74,16 @@ public class EmptyOptionSetTest {
     @Test( expected = NullPointerException.class )
     public void valueOfWithNullString() {
         empty.valueOf( (String) null );
+    }
+
+    @Test( expected = NullPointerException.class )
+    public void valueOfOptionalWithNullString() {
+        empty.valueOfOptional( (String) null );
+    }
+
+    @Test( expected = NullPointerException.class )
+    public void valueOfOptionalWithNullOptionSpec() {
+        empty.valueOfOptional( (OptionSpec<?>) null );
     }
 
     @Test( expected = NullPointerException.class )

--- a/src/test/java/joptsimple/HandlingDefaultValuesForOptionArgumentsTest.java
+++ b/src/test/java/joptsimple/HandlingDefaultValuesForOptionArgumentsTest.java
@@ -27,6 +27,7 @@ package joptsimple;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Optional;
 
 import static java.math.BigDecimal.*;
 import static java.util.Arrays.*;
@@ -54,7 +55,10 @@ public class HandlingDefaultValuesForOptionArgumentsTest extends AbstractOptionP
         Integer expectedArgument = 1;
         assertEquals( expectedArgument, options.valueOf( "a" ) );
         assertEquals( expectedArgument, options.valueOf( optionA ) );
+        assertEquals( Optional.of( expectedArgument ), options.valueOfOptional( "a" ) );
+        assertEquals( Optional.of( expectedArgument ), options.valueOfOptional( optionA ) );
         assertEquals( expectedArgument, optionA.value( options ) );
+        assertEquals( Optional.of( expectedArgument ), optionA.valueOptional( options ) );
         assertEquals( singletonList( expectedArgument ), options.valuesOf( "a" ) );
         assertEquals( singletonList( expectedArgument ), options.valuesOf( optionA ) );
         assertEquals( singletonList( expectedArgument ), optionA.values( options ) );
@@ -81,7 +85,10 @@ public class HandlingDefaultValuesForOptionArgumentsTest extends AbstractOptionP
         Long expectedArgument = -1L;
         assertEquals( expectedArgument, options.valueOf( "a" ) );
         assertEquals( expectedArgument, options.valueOf( optionA ) );
+        assertEquals( Optional.of( expectedArgument ), options.valueOfOptional( "a" ) );
+        assertEquals( Optional.of( expectedArgument ), options.valueOfOptional( optionA ) );
         assertEquals( expectedArgument, optionA.value( options ) );
+        assertEquals( Optional.of( expectedArgument ), optionA.valueOptional( options ) );
         assertEquals( singletonList( expectedArgument ), options.valuesOf( "a" ) );
         assertEquals( singletonList( expectedArgument ), options.valuesOf( optionA ) );
         assertEquals( singletonList( expectedArgument ), optionA.values( options ) );
@@ -101,7 +108,10 @@ public class HandlingDefaultValuesForOptionArgumentsTest extends AbstractOptionP
         Long expectedArgument = 2L;
         assertEquals( expectedArgument, options.valueOf( "a" ) );
         assertEquals( expectedArgument, options.valueOf( optionA ) );
+        assertEquals( Optional.of( expectedArgument ), options.valueOfOptional( "a" ) );
+        assertEquals( Optional.of( expectedArgument ), options.valueOfOptional( optionA ) );
         assertEquals( expectedArgument, optionA.value( options ) );
+        assertEquals( Optional.of( expectedArgument ), optionA.valueOptional( options ) );
         assertEquals( singletonList( expectedArgument ), options.valuesOf( "a" ) );
         assertEquals( singletonList( expectedArgument ), options.valuesOf( optionA ) );
         assertEquals( singletonList( expectedArgument ), optionA.values( options ) );
@@ -120,7 +130,10 @@ public class HandlingDefaultValuesForOptionArgumentsTest extends AbstractOptionP
         assertFalse( options.hasArgument( optionA ) );
         assertEquals( TEN, options.valueOf( "a" ) );
         assertEquals( TEN, options.valueOf( optionA ) );
+        assertEquals( Optional.of( TEN ), options.valueOfOptional( "a" ) );
+        assertEquals( Optional.of( TEN ), options.valueOfOptional( optionA ) );
         assertEquals( TEN, optionA.value( options ) );
+        assertEquals( Optional.of( TEN ), optionA.valueOptional( options ) );
         assertEquals( singletonList( TEN ), options.valuesOf( "a" ) );
         assertEquals( singletonList( TEN ), options.valuesOf( optionA ) );
         assertEquals( singletonList( TEN ), optionA.values( options ) );
@@ -139,7 +152,10 @@ public class HandlingDefaultValuesForOptionArgumentsTest extends AbstractOptionP
         assertFalse( options.hasArgument( optionA ) );
         assertEquals( TEN, options.valueOf( "a" ) );
         assertEquals( TEN, options.valueOf( optionA ) );
+        assertEquals( Optional.of( TEN ), options.valueOfOptional( "a" ) );
+        assertEquals( Optional.of( TEN ), options.valueOfOptional( optionA ) );
         assertEquals( TEN, optionA.value( options ) );
+        assertEquals( Optional.of( TEN ), optionA.valueOptional( options ) );
         assertEquals( singletonList( TEN ), options.valuesOf( "a" ) );
         assertEquals( singletonList( TEN ), options.valuesOf( optionA ) );
         assertEquals( singletonList( TEN ), optionA.values( options ) );

--- a/src/test/java/joptsimple/OptionParserNewDeclarationTest.java
+++ b/src/test/java/joptsimple/OptionParserNewDeclarationTest.java
@@ -28,6 +28,7 @@ package joptsimple;
 import java.math.BigInteger;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.util.Optional;
 
 import static java.lang.Boolean.*;
 import static java.util.Collections.*;
@@ -55,9 +56,11 @@ public class OptionParserNewDeclarationTest extends AbstractOptionParserFixture 
         assertOptionDetected( options, "a" );
         assertOptionDetected( options, "b" );
         assertEquals( TRUE, options.valueOf( "a" ) );
-        assertEquals( singletonList( TRUE ), options.valuesOf( "a" ) );
+        assertEquals( Optional.of( true ) , options.valueOfOptional( "a" ) );
+        assertEquals( singletonList( true ), options.valuesOf( "a" ) );
         assertEquals( FALSE, options.valueOf( "b" ) );
-        assertEquals( singletonList( FALSE ), options.valuesOf( "b" ) );
+        assertEquals( Optional.of( false ) , options.valueOfOptional( "b" ) );
+        assertEquals( singletonList( false ), options.valuesOf( "b" ) );
         assertEquals( emptyList(), options.nonOptionArguments() );
     }
 
@@ -71,8 +74,10 @@ public class OptionParserNewDeclarationTest extends AbstractOptionParserFixture 
         assertOptionDetected( options, "a" );
         assertOptionDetected( options, "b" );
         assertEquals( Byte.valueOf( "-1" ), options.valueOf( "a" ) );
+        assertEquals( Optional.of( Byte.valueOf( "-1" ) ), options.valueOfOptional( "a" ) );
         assertEquals( singletonList( Byte.valueOf( "-1" ) ), options.valuesOf( "a" ) );
         assertEquals( Byte.valueOf( "-2" ), options.valueOf( "b" ) );
+        assertEquals( Optional.of( Byte.valueOf( "-2" ) ), options.valueOfOptional( "b" ) );
         assertEquals( singletonList( Byte.valueOf( "-2" ) ), options.valuesOf( "b" ) );
         assertEquals( emptyList(), options.nonOptionArguments() );
     }
@@ -87,9 +92,11 @@ public class OptionParserNewDeclarationTest extends AbstractOptionParserFixture 
         assertOptionDetected( options, "a" );
         assertOptionDetected( options, "b" );
         assertEquals( Double.valueOf( "3.1415926D" ), options.valueOf( "a" ) );
-        assertEquals( singletonList( Double.valueOf( "3.1415926D" ) ), options.valuesOf( "a" ) );
+        assertEquals( Optional.of( 3.1415926D ), options.valueOfOptional( "a" ) );
+        assertEquals( singletonList( 3.1415926D ), options.valuesOf( "a" ) );
         assertEquals( Double.valueOf( "6.02E23" ), options.valueOf( "b" ) );
-        assertEquals( singletonList( Double.valueOf( "6.02E23" ) ), options.valuesOf( "b" ) );
+        assertEquals( Optional.of( 6.02E23 ), options.valueOfOptional( "b" ) );
+        assertEquals( singletonList( 6.02E23 ), options.valuesOf( "b" ) );
         assertEquals( emptyList(), options.nonOptionArguments() );
     }
 
@@ -103,9 +110,11 @@ public class OptionParserNewDeclarationTest extends AbstractOptionParserFixture 
         assertOptionDetected( options, "a" );
         assertOptionDetected( options, "b" );
         assertEquals( Float.valueOf( "3.1415926F" ), options.valueOf( "a" ) );
-        assertEquals( singletonList( Float.valueOf( "3.1415926F" ) ), options.valuesOf( "a" ) );
+        assertEquals( Optional.of( 3.1415926F ), options.valueOfOptional( "a" ) );
+        assertEquals( singletonList( 3.1415926F ), options.valuesOf( "a" ) );
         assertEquals( Float.valueOf( "6.02E23F" ), options.valueOf( "b" ) );
-        assertEquals( singletonList( Float.valueOf( "6.02E23F" ) ), options.valuesOf( "b" ) );
+        assertEquals( Optional.of( 6.02E23F ), options.valueOfOptional( "b" ) );
+        assertEquals( singletonList( 6.02E23F ), options.valuesOf( "b" ) );
         assertEquals( emptyList(), options.nonOptionArguments() );
     }
 
@@ -119,9 +128,11 @@ public class OptionParserNewDeclarationTest extends AbstractOptionParserFixture 
         assertOptionDetected( options, "a" );
         assertOptionDetected( options, "b" );
         assertEquals( Integer.valueOf( "12" ), options.valueOf( "a" ) );
-        assertEquals( singletonList( Integer.valueOf( "12" ) ), options.valuesOf( "a" ) );
+        assertEquals( Optional.of( 12 ), options.valueOfOptional( "a" ) );
+        assertEquals( singletonList( 12 ), options.valuesOf( "a" ) );
         assertEquals( Integer.valueOf( "34" ), options.valueOf( "b" ) );
-        assertEquals( singletonList( Integer.valueOf( "34" ) ), options.valuesOf( "b" ) );
+        assertEquals( Optional.of( 34 ), options.valueOfOptional( "b" ) );
+        assertEquals( singletonList( 34 ), options.valuesOf( "b" ) );
         assertEquals( emptyList(), options.nonOptionArguments() );
     }
 
@@ -135,9 +146,11 @@ public class OptionParserNewDeclarationTest extends AbstractOptionParserFixture 
         assertOptionDetected( options, "a" );
         assertOptionDetected( options, "b" );
         assertEquals( Long.valueOf( "123454678901234" ), options.valueOf( "a" ) );
-        assertEquals( singletonList( Long.valueOf( "123454678901234" ) ), options.valuesOf( "a" ) );
+        assertEquals( Optional.of( 123454678901234L ), options.valueOfOptional( "a" ) );
+        assertEquals( singletonList( 123454678901234L ), options.valuesOf( "a" ) );
         assertEquals( Long.valueOf( "98765432109876" ), options.valueOf( "b" ) );
-        assertEquals( singletonList( Long.valueOf( "98765432109876" ) ), options.valuesOf( "b" ) );
+        assertEquals( Optional.of( 98765432109876L ), options.valueOfOptional( "b" ) );
+        assertEquals( singletonList( 98765432109876L ), options.valuesOf( "b" ) );
         assertEquals( emptyList(), options.nonOptionArguments() );
     }
 
@@ -151,8 +164,10 @@ public class OptionParserNewDeclarationTest extends AbstractOptionParserFixture 
         assertOptionDetected( options, "a" );
         assertOptionDetected( options, "b" );
         assertEquals( Short.valueOf( "5675" ), options.valueOf( "a" ) );
+        assertEquals( Optional.of( Short.valueOf( "5675" ) ), options.valueOfOptional( "a" ) );
         assertEquals( singletonList( Short.valueOf( "5675" ) ), options.valuesOf( "a" ) );
         assertEquals( Short.valueOf( "345" ), options.valueOf( "b" ) );
+        assertEquals( Optional.of( Short.valueOf( "345" ) ), options.valueOfOptional( "b" ) );
         assertEquals( singletonList( Short.valueOf( "345" ) ), options.valuesOf( "b" ) );
         assertEquals( emptyList(), options.nonOptionArguments() );
     }
@@ -167,8 +182,10 @@ public class OptionParserNewDeclarationTest extends AbstractOptionParserFixture 
         assertOptionDetected( options, "a" );
         assertOptionDetected( options, "b" );
         assertEquals( java.sql.Date.valueOf( "2001-09-11" ), options.valueOf( "a" ) );
+        assertEquals( Optional.of( java.sql.Date.valueOf( "2001-09-11" ) ), options.valueOfOptional( "a" ) );
         assertEquals( singletonList( java.sql.Date.valueOf( "2001-09-11" ) ), options.valuesOf( "a" ) );
         assertEquals( java.sql.Date.valueOf( "1941-12-07" ), options.valueOf( "b" ) );
+        assertEquals( Optional.of( java.sql.Date.valueOf( "1941-12-07" ) ), options.valueOfOptional( "b" ) );
         assertEquals( singletonList( java.sql.Date.valueOf( "1941-12-07" ) ), options.valuesOf( "b" ) );
         assertEquals( emptyList(), options.nonOptionArguments() );
     }
@@ -183,8 +200,10 @@ public class OptionParserNewDeclarationTest extends AbstractOptionParserFixture 
         assertOptionDetected( options, "a" );
         assertOptionDetected( options, "b" );
         assertEquals( Time.valueOf( "08:57:39" ), options.valueOf( "a" ) );
+        assertEquals( Optional.of( Time.valueOf( "08:57:39" ) ), options.valueOfOptional( "a" ) );
         assertEquals( singletonList( Time.valueOf( "08:57:39" ) ), options.valuesOf( "a" ) );
         assertEquals( Time.valueOf( "23:59:59" ), options.valueOf( "b" ) );
+        assertEquals( Optional.of( Time.valueOf( "23:59:59" ) ), options.valueOfOptional( "b" ) );
         assertEquals( singletonList( Time.valueOf( "23:59:59" ) ), options.valuesOf( "b" ) );
         assertEquals( emptyList(), options.nonOptionArguments() );
     }
@@ -199,8 +218,12 @@ public class OptionParserNewDeclarationTest extends AbstractOptionParserFixture 
         assertOptionDetected( options, "a" );
         assertOptionDetected( options, "b" );
         assertEquals( Timestamp.valueOf( "1970-01-01 00:00:00" ), options.valueOf( "a" ) );
+        assertEquals( Optional.of( Timestamp.valueOf( "1970-01-01 00:00:00" ) ), options.valueOfOptional( "a" ) );
         assertEquals( singletonList( Timestamp.valueOf( "1970-01-01 00:00:00" ) ), options.valuesOf( "a" ) );
         assertEquals( Timestamp.valueOf( "1979-12-31 23:59:59.0123456" ), options.valueOf( "b" ) );
+        assertEquals(
+            Optional.of( Timestamp.valueOf( "1979-12-31 23:59:59.0123456" ) ),
+            options.valueOfOptional( "b" ) );
         assertEquals( singletonList( Timestamp.valueOf( "1979-12-31 23:59:59.0123456" ) ), options.valuesOf( "b" ) );
         assertEquals( emptyList(), options.nonOptionArguments() );
     }
@@ -235,9 +258,11 @@ public class OptionParserNewDeclarationTest extends AbstractOptionParserFixture 
         assertOptionDetected( options, "a" );
         assertOptionDetected( options, "b" );
         assertEquals( Integer.valueOf( "-1" ), options.valueOf( "a" ) );
-        assertEquals( singletonList( Integer.valueOf( "-1" ) ), options.valuesOf( "a" ) );
+        assertEquals( Optional.of( -1 ), options.valueOfOptional( "a" ) );
+        assertEquals( singletonList( -1 ), options.valuesOf( "a" ) );
         assertEquals( Integer.valueOf( "-2" ), options.valueOf( "b" ) );
-        assertEquals( singletonList( Integer.valueOf( "-2" ) ), options.valuesOf( "b" ) );
+        assertEquals( Optional.of( -2 ), options.valueOfOptional( "b" ) );
+        assertEquals( singletonList( -2 ), options.valuesOf( "b" ) );
         assertEquals( emptyList(), options.nonOptionArguments() );
     }
 
@@ -258,6 +283,10 @@ public class OptionParserNewDeclarationTest extends AbstractOptionParserFixture 
         assertNull( options.valueOf( "a" ) );
         assertNull( options.valueOf( "2" ) );
         assertNull( options.valueOf( "b" ) );
+        assertEquals( Optional.empty(), options.valueOfOptional( "1" ) );
+        assertEquals( Optional.empty(), options.valueOfOptional( "a" ) );
+        assertEquals( Optional.empty(), options.valueOfOptional( "2" ) );
+        assertEquals( Optional.empty(), options.valueOfOptional( "b" ) );
         assertEquals( emptyList(), options.valuesOf( "1" ) );
         assertEquals( emptyList(), options.valuesOf( "a" ) );
         assertEquals( emptyList(), options.valuesOf( "2" ) );
@@ -279,11 +308,14 @@ public class OptionParserNewDeclarationTest extends AbstractOptionParserFixture 
         assertOptionDetected( options, "b" );
         assertOptionNotDetected( options, "2" );
         assertNull( options.valueOf( "1" ) );
+        assertEquals( Optional.empty(), options.valueOfOptional( "1" ) );
         assertNull( options.valueOf( "a" ) );
+        assertEquals( Optional.empty(), options.valueOfOptional( "a" ) );
         assertEquals( Integer.valueOf( "-2" ), options.valueOf( "b" ) );
+        assertEquals( Optional.of( -2 ), options.valueOfOptional( "b" ) );
         assertEquals( emptyList(), options.valuesOf( "1" ) );
         assertEquals( emptyList(), options.valuesOf( "a" ) );
-        assertEquals( singletonList( Integer.valueOf( "-2" ) ), options.valuesOf( "b" ) );
+        assertEquals( singletonList( -2 ), options.valuesOf( "b" ) );
         assertEquals( emptyList(), options.nonOptionArguments() );
     }
 }

--- a/src/test/java/joptsimple/OptionParserOptionExceptionTest.java
+++ b/src/test/java/joptsimple/OptionParserOptionExceptionTest.java
@@ -75,4 +75,14 @@ public class OptionParserOptionExceptionTest extends AbstractOptionParserFixture
 
         options.valueOf( "e" );
     }
+
+    @Test
+    public void valueOfOptionalWhenMultiples() {
+        parser.accepts( "e" ).withRequiredArg();
+        OptionSet options = parser.parse( "-e", "foo", "-e", "bar" );
+        thrown.expect( MultipleArgumentsForOptionException.class );
+        thrown.expect( withOption( "e" ) );
+
+        options.valueOfOptional( "e" );
+    }
 }

--- a/src/test/java/joptsimple/OptionParserTest.java
+++ b/src/test/java/joptsimple/OptionParserTest.java
@@ -25,6 +25,8 @@
 
 package joptsimple;
 
+import java.util.Optional;
+
 import static java.lang.Boolean.*;
 import static java.util.Arrays.*;
 import static java.util.Collections.*;
@@ -42,9 +44,9 @@ import static org.junit.Assert.*;
 public class OptionParserTest extends AbstractOptionParserFixture {
     @Test
     public void optionsAndNonOptionsInterspersed() {
-        parser.accepts( "i" ).withOptionalArg();
+        parser.accepts("i" ).withOptionalArg();
         parser.accepts( "j" ).withOptionalArg();
-        parser.accepts( "k" );
+        OptionSpec<Void> k = parser.accepts( "k" );
 
         OptionSet options =
             parser.parse( "-ibar", "-i", "junk", "xyz", "-jixnay", "foo", "-k", "blah", "--", "yermom" );
@@ -56,6 +58,7 @@ public class OptionParserTest extends AbstractOptionParserFixture {
         assertEquals( singletonList( "ixnay" ), options.valuesOf( "j" ) );
         assertEquals( emptyList(), options.valuesOf( "k" ) );
         assertEquals( asList( "xyz", "foo", "blah", "yermom" ), options.nonOptionArguments() );
+        assertEquals( Optional.empty(), k.valueOptional( options ) );
     }
 
     @Test
@@ -167,9 +170,11 @@ public class OptionParserTest extends AbstractOptionParserFixture {
         assertOptionDetected( options, "a" );
         assertOptionDetected( options, "b" );
         assertEquals( FALSE, options.valueOf( "a" ) );
-        assertEquals( singletonList( FALSE ), options.valuesOf( "a" ) );
+        assertEquals( Optional.of( false ), options.valueOfOptional( "a" ) );
+        assertEquals( singletonList( false ), options.valuesOf( "a" ) );
         assertEquals( Integer.valueOf( "3" ), options.valueOf( "b" ) );
-        assertEquals( singletonList( Integer.valueOf( "3" ) ), options.valuesOf( "b" ) );
+        assertEquals( Optional.of( 3 ), options.valueOfOptional( "b" ) );
+        assertEquals( singletonList( 3 ), options.valuesOf( "b" ) );
         assertEquals( singletonList( "extra" ), options.nonOptionArguments() );
     }
 
@@ -237,6 +242,7 @@ public class OptionParserTest extends AbstractOptionParserFixture {
 
         assertOptionDetected( options, "i" );
         assertEquals( "", optionI.value( options ) );
+        assertEquals( Optional.of( "" ), optionI.valueOptional( options ) );
     }
 
     @Test
@@ -248,6 +254,7 @@ public class OptionParserTest extends AbstractOptionParserFixture {
 
         assertOptionDetected( options, "j" );
         assertEquals( whitespace, optionJ.value( options ) );
+        assertEquals( Optional.of( whitespace ), optionJ.valueOptional( options ) );
     }
 
     @Test
@@ -259,6 +266,7 @@ public class OptionParserTest extends AbstractOptionParserFixture {
 
         assertOptionDetected( options, "j" );
         assertEquals( withEmbeddedWhitespace, optionJ.value( options ) );
+        assertEquals( Optional.of( withEmbeddedWhitespace ), optionJ.valueOptional( options ) );
     }
     
     @Test

--- a/src/test/java/joptsimple/PopulatedOptionSetTest.java
+++ b/src/test/java/joptsimple/PopulatedOptionSetTest.java
@@ -25,6 +25,8 @@
 
 package joptsimple;
 
+import java.util.Optional;
+
 import static java.util.Collections.*;
 
 import org.junit.Before;
@@ -55,6 +57,12 @@ public class PopulatedOptionSetTest {
     public void valueOf() {
         assertNull( populated.valueOf( "a" ) );
         assertEquals( "arg-of-b", populated.valueOf( "b" ) );
+    }
+
+    @Test
+    public void valueOfOptional() {
+        assertEquals( Optional.empty(), populated.valueOfOptional( "a" ) );
+        assertEquals( Optional.of( "arg-of-b" ), populated.valueOfOptional( "b" ) );
     }
 
     @Test

--- a/src/test/java/joptsimple/ShortOptionsNoArgumentTest.java
+++ b/src/test/java/joptsimple/ShortOptionsNoArgumentTest.java
@@ -25,6 +25,8 @@
 
 package joptsimple;
 
+import java.util.Optional;
+
 import static java.util.Arrays.*;
 import static java.util.Collections.*;
 
@@ -51,6 +53,7 @@ public class ShortOptionsNoArgumentTest extends AbstractOptionParserFixture {
 
         assertOptionDetected( options, "a" );
         assertNull( options.valueOf( "a" ) );
+        assertEquals( Optional.empty(), options.valueOfOptional( "a" ) );
         assertEquals( emptyList(), options.nonOptionArguments() );
     }
 
@@ -62,6 +65,8 @@ public class ShortOptionsNoArgumentTest extends AbstractOptionParserFixture {
         assertOptionDetected( options, "b" );
         assertNull( options.valueOf( "a" ) );
         assertNull( options.valueOf( "b" ) );
+        assertEquals( Optional.empty(), options.valueOfOptional( "a" ) );
+        assertEquals( Optional.empty(), options.valueOfOptional( "b" ) );
         assertEquals( emptyList(), options.nonOptionArguments() );
     }
 
@@ -71,6 +76,7 @@ public class ShortOptionsNoArgumentTest extends AbstractOptionParserFixture {
 
         assertOptionDetected( options, "c" );
         assertNull( options.valueOf( "c" ) );
+        assertEquals( Optional.empty(), options.valueOfOptional( "c" ) );
         assertEquals( singletonList( "foo" ), options.nonOptionArguments() );
     }
 
@@ -84,6 +90,9 @@ public class ShortOptionsNoArgumentTest extends AbstractOptionParserFixture {
         assertNull( options.valueOf( "a" ) );
         assertNull( options.valueOf( "b" ) );
         assertNull( options.valueOf( "c" ) );
+        assertEquals( Optional.empty(), options.valueOfOptional( "a" ) );
+        assertEquals( Optional.empty(), options.valueOfOptional( "b" ) );
+        assertEquals( Optional.empty(), options.valueOfOptional( "c" ) );
         assertEquals( emptyList(), options.nonOptionArguments() );
     }
 
@@ -93,6 +102,7 @@ public class ShortOptionsNoArgumentTest extends AbstractOptionParserFixture {
 
         assertOptionDetected( options, "a" );
         assertNull( options.valueOf( "a" ) );
+        assertEquals( Optional.empty(), options.valueOfOptional( "a" ) );
         assertOptionNotDetected( options, "b" );
         assertEquals( asList( "-a", "-b" ), options.nonOptionArguments() );
     }
@@ -103,6 +113,7 @@ public class ShortOptionsNoArgumentTest extends AbstractOptionParserFixture {
 
         assertOptionDetected( options, "b" );
         assertNull( options.valueOf( "b" ) );
+        assertEquals( Optional.empty(), options.valueOfOptional( "b" ) );
         assertEquals( emptyList(), options.nonOptionArguments() );
     }
 }

--- a/src/test/java/joptsimple/ShortOptionsRequiredArgumentTest.java
+++ b/src/test/java/joptsimple/ShortOptionsRequiredArgumentTest.java
@@ -25,6 +25,8 @@
 
 package joptsimple;
 
+import java.util.Optional;
+
 import static java.util.Arrays.*;
 import static java.util.Collections.*;
 
@@ -60,6 +62,7 @@ public class ShortOptionsRequiredArgumentTest extends AbstractOptionParserFixtur
 
         assertOptionDetected( options, "d" );
         assertEquals( "foo", options.valueOf( "d" ) );
+        assertEquals( Optional.of( "foo" ), options.valueOfOptional( "d" ) );
         assertEquals( emptyList(), options.nonOptionArguments() );
     }
 
@@ -78,6 +81,7 @@ public class ShortOptionsRequiredArgumentTest extends AbstractOptionParserFixtur
         assertOptionDetected( options, "f" );
         assertOptionDetected( options, "e" );
         assertEquals( "foo", options.valueOf( "d" ) );
+        assertEquals( Optional.of( "foo" ), options.valueOfOptional( "d" ) );
     }
     
     @Test
@@ -89,6 +93,7 @@ public class ShortOptionsRequiredArgumentTest extends AbstractOptionParserFixtur
         assertOptionNotDetected( options, "e" );
         
         assertEquals( "e", options.valueOf( "d" ) );
+        assertEquals( Optional.of( "e" ), options.valueOfOptional( "d" ) );
     }
 
     @Test
@@ -98,6 +103,7 @@ public class ShortOptionsRequiredArgumentTest extends AbstractOptionParserFixtur
         assertOptionDetected( options, "d" );
         assertOptionNotDetected( options, "infile" );
         assertEquals( "--infile", options.valueOf( "d" ) );
+        assertEquals( Optional.of( "--infile" ), options.valueOfOptional( "d" ) );
         assertEquals( emptyList(), options.nonOptionArguments() );
     }
 

--- a/src/test/java/joptsimple/TypesafeOptionArgumentRetrievalTest.java
+++ b/src/test/java/joptsimple/TypesafeOptionArgumentRetrievalTest.java
@@ -26,6 +26,7 @@
 package joptsimple;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.Test;
 
@@ -65,6 +66,7 @@ public class TypesafeOptionArgumentRetrievalTest extends AbstractOptionParserFix
 
         assertTrue( options.has( optionB ) );
         assertEquals( Double.valueOf( 3.14D ), optionB.value( options ) );
+        assertEquals( Optional.of( 3.14D ), optionB.valueOptional( options ) );
         assertEquals( singletonList( 3.14D ), optionB.values( options ) );
     }
 


### PR DESCRIPTION
Adding to OptionSpec and OptionSet to support retrieval of
single parsed option arguments as Optionals.